### PR TITLE
Bump version to 0.1.17 (ITensorBot smoke test)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PkgDependents"
 uuid = "ae191fcf-7ec6-40a6-95c9-dedb80b28f91"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/PkgDependents.jl
+++ b/src/PkgDependents.jl
@@ -79,7 +79,7 @@ function dependencies(
 end
 
 to_registry(registry::RegistryInstances.RegistryInstance) = registry
-to_registry(registryname::String) =  registryinstance_from_registryname(registryname)
+to_registry(registryname::String) = registryinstance_from_registryname(registryname)
 
 function dependents(
         pkgname::String; registries = RegistryInstances.reachable_registries(), weakdeps = true

--- a/src/PkgDependents.jl
+++ b/src/PkgDependents.jl
@@ -79,7 +79,7 @@ function dependencies(
 end
 
 to_registry(registry::RegistryInstances.RegistryInstance) = registry
-to_registry(registryname::String) = registryinstance_from_registryname(registryname)
+to_registry(registryname::String) =  registryinstance_from_registryname(registryname)
 
 function dependents(
         pkgname::String; registries = RegistryInstances.reachable_registries(), weakdeps = true


### PR DESCRIPTION
Patch-version bump to exercise the organization's Registrator, FormatPullRequest, and TagBot workflows under a new automation-account token. FormatPullRequest attribution was verified mid-PR (format commit and reaction both authored by the bot); Registrator and TagBot are verified on merge and the subsequent registry PR respectively.